### PR TITLE
Updated CHUNITHM guides to reflect segatools change from [gpio] to [system]

### DIFF
--- a/docs/games/chunithmluminous/setup.md
+++ b/docs/games/chunithmluminous/setup.md
@@ -159,7 +159,7 @@
     setting. Do not add another key.
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw2=1 ; WRONG!
     ```
@@ -178,14 +178,18 @@
     appdata=../../AppData
     ```
 
-#### `[gpio]`
+#### `[system] (formerly [gpio])`
+
+!!! warning
+
+    As of 2024-08-20, the [gpio] section in segatools has been renamed to [system].
 
 !!! tip ""
 
     - If you have a 120Hz monitor, set `dipsw2` and `dipsw3` to 0:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=0
     dipsw3=0
     ```
@@ -193,7 +197,7 @@
     - If you have a 60Hz monitor, set `dipsw2` and `dipsw3` to 1:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw3=1
     ```

--- a/docs/games/chunithmnew/setup.md
+++ b/docs/games/chunithmnew/setup.md
@@ -159,7 +159,7 @@
     setting. Do not add another key.
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw2=1 ; WRONG!
     ```
@@ -178,14 +178,18 @@
     appdata=../../AppData
     ```
 
-#### `[gpio]`
+#### `[system] (formerly [gpio])`
+
+!!! warning
+
+    As of 2024-08-20, the [gpio] section in segatools has been renamed to [system].
 
 !!! tip ""
 
     - If you have a 120Hz monitor, set `dipsw2` and `dipsw3` to 0:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=0
     dipsw3=0
     ```
@@ -193,7 +197,7 @@
     - If you have a 60Hz monitor, set `dipsw2` and `dipsw3` to 1:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw3=1
     ```

--- a/docs/games/chunithmnewplus/setup.md
+++ b/docs/games/chunithmnewplus/setup.md
@@ -159,7 +159,7 @@
     setting. Do not add another key.
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw2=1 ; WRONG!
     ```
@@ -178,14 +178,18 @@
     appdata=../../AppData
     ```
 
-#### `[gpio]`
+#### `[system] (formerly [gpio])`
+
+!!! warning
+
+    As of 2024-08-20, the [gpio] section in segatools has been renamed to [system].
 
 !!! tip ""
 
     - If you have a 120Hz monitor, set `dipsw2` and `dipsw3` to 0:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=0
     dipsw3=0
     ```
@@ -193,7 +197,7 @@
     - If you have a 60Hz monitor, set `dipsw2` and `dipsw3` to 1:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw3=1
     ```

--- a/docs/games/chunithmsun/setup.md
+++ b/docs/games/chunithmsun/setup.md
@@ -159,7 +159,7 @@
     setting. Do not add another key.
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw2=1 ; WRONG!
     ```
@@ -178,14 +178,18 @@
     appdata=../../AppData
     ```
 
-#### `[gpio]`
+#### `[system] (formerly [gpio])`
+
+!!! warning
+
+    As of 2024-08-20, the [gpio] section in segatools has been renamed to [system].
 
 !!! tip ""
 
     - If you have a 120Hz monitor, set `dipsw2` and `dipsw3` to 0:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=0
     dipsw3=0
     ```
@@ -193,7 +197,7 @@
     - If you have a 60Hz monitor, set `dipsw2` and `dipsw3` to 1:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw3=1
     ```

--- a/docs/games/chunithmsunplus/setup.md
+++ b/docs/games/chunithmsunplus/setup.md
@@ -159,7 +159,7 @@
     setting. Do not add another key.
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw2=1 ; WRONG!
     ```
@@ -178,14 +178,18 @@
     appdata=../../AppData
     ```
 
-#### `[gpio]`
+#### `[system] (formerly [gpio])`
+
+!!! warning
+
+    As of 2024-08-20, the [gpio] section in segatools has been renamed to [system].
 
 !!! tip ""
 
     - If you have a 120Hz monitor, set `dipsw2` and `dipsw3` to 0:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=0
     dipsw3=0
     ```
@@ -193,7 +197,7 @@
     - If you have a 60Hz monitor, set `dipsw2` and `dipsw3` to 1:
 
     ```ini
-    [gpio]
+    [system]
     dipsw2=1
     dipsw3=1
     ```


### PR DESCRIPTION
Updated instructions in line with latest segatools release; https://gitea.tendokyu.moe/Dniel97/segatools/releases/tag/2024-08-20