### PR TITLE
replace broken iidx link in resources.md

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -42,7 +42,7 @@
 
 	- [iidx.org](https://iidx.org/) - The go to guide for mechanics and skill related things
 	- [sp12](https://sp12.iidx.app/) - IIDX SP☆12 reference site/difficulty tier list
-	- [beatmania.app](https://beatmania.app/!/) - IIDX difficulty tier list
+	- [beatmania.app](https://beatmania.app/!/) - IIDX INFINITAS difficulty tier list
 	- [Statistik](http://statistik.benhgreen.com/) - IIDX difficulty tier list
 	- [atwiki](https://w.atwiki.jp/bemani2sp/sp/) - IIDX wiki in JP (includes tier lists)
 	- [textage.cc](https://textage.cc/score/) - Chart viewing resource

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -42,7 +42,7 @@
 
 	- [iidx.org](https://iidx.org/) - The go to guide for mechanics and skill related things
 	- [sp12](https://sp12.iidx.app/) - IIDX SP☆12 reference site/difficulty tier list
-	- [iidx.insane.pe.kr](https://iidx.insane.pe.kr/!/) - IIDX difficulty tier list
+	- [beatmania.app](https://beatmania.app/!/) - IIDX difficulty tier list
 	- [Statistik](http://statistik.benhgreen.com/) - IIDX difficulty tier list
 	- [atwiki](https://w.atwiki.jp/bemani2sp/sp/) - IIDX wiki in JP (includes tier lists)
 	- [textage.cc](https://textage.cc/score/) - Chart viewing resource


### PR DESCRIPTION
iidx.inasne.pe.kr only accessible via wayback machine now since the site is entirely dead, beatmania.app seems to be a replacement but aimed at inifnitas specifically

other link from i saw from iidx.org which was supposedly a replacement for this has returned 502 for a while - https://iidx.len-ch.com/ 