### PR TITLE
not_in_nav, minor chunithm changes

### DIFF
--- a/docs/games/chunithmluminous/setup.md
+++ b/docs/games/chunithmluminous/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chunithmluminousplus/setup.md
+++ b/docs/games/chunithmluminousplus/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chunithmnew/setup.md
+++ b/docs/games/chunithmnew/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chunithmnewplus/setup.md
+++ b/docs/games/chunithmnewplus/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chunithmsun/setup.md
+++ b/docs/games/chunithmsun/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chunithmsunplus/setup.md
+++ b/docs/games/chunithmsunplus/setup.md
@@ -69,6 +69,8 @@
 
     <img width="500" src="/img/chunithm/sdhd/setup/2_chunithmoption.png">
 
+!!! warning "If you plan to connect to a network (Hosted or Local), the `A001` option folder for your specific game version is required. This option contains a special Event file that lets the game connect."
+
 #### Installing ICFs
 
 !!! tip ""

--- a/docs/games/chusan/controllers.md
+++ b/docs/games/chusan/controllers.md
@@ -154,7 +154,7 @@
     adb reverse tcp:52468 tcp:52468
     ```
 
-    - Start `brokenithm_server.exe`.
+    - Start brokenithm_server in TCP mode with the -T command line flag, `brokenithm_server.exe -T`.
     - On your Android device, open Brokenithm, and change the address to `0.0.0.0`.
         - If the text box to the left of the "SETTINGS" button say "UDP", tap on it
     once to switch to "TCP" mode.
@@ -165,13 +165,13 @@
     again. To do this automatically when the game starts, add a line to the `start.bat`
     script **before** the `brokenithm_server` line:
 
-    ```batch hl_lines="5"
+    ```batch hl_lines="5 6"
     @echo off
 
     pushd %~dp0
 
     start /min platform-tools\adb reverse tcp:52468 tcp:52468
-    start /min brokenithm_server
+    start /min brokenithm_server -T
     start /min inject_x64 -d -k chusanhook_x64.dll amdaemon.exe -c config_common.json config_server.json config_client.json config_cvt.json config_sp.json config_hook.json
     inject_x86 -d -k chusanhook_x86.dll chusanApp.exe
     taskkill /f /im amdaemon.exe > nul 2>&1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,11 @@ nav:
     - "SoftEther VPN for Cab-to-Cab": "extras/softether.md"
   - Other Resources: resources.md
 
+not_in_nav: |
+  games/chusan/c2c.md
+  games/chusan/controllers.md
+  games/chusan/troubleshooting.md
+
 theme:
   name: material
   logo: img/logo/website-logo.svg


### PR DESCRIPTION
Added the not_in_nav section to mkdocs.yml to remove the warnings about pages in the /chusan/ directory not being referenced in nav. Minor issue but may cause some confusion for people looking to contribute who are running mkdocs locally for testing.

CHUNITHM controller guide was missing the command line flag required for brokenithm_server to launch in TCP mode. This has now been added.

Have seen several people lately try and connect to online servers with CHUNITHM without realising that option data, despite the name, is REQUIRED (at least, A001). Added a warning about this to each gamesetup page.

🫡