### PR TITLE
Make Chuni Troubleshooting and Controllers hyperlinks lead to game-specific pages + Small Ongeki guide formatting and fixes

### DIFF
--- a/docs/games/chunithmluminous/setup.md
+++ b/docs/games/chunithmluminous/setup.md
@@ -298,7 +298,7 @@
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmluminous/troubleshooting.md) page."
 
 !!! tip
 
@@ -371,8 +371,8 @@
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmluminous/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmluminous/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/chunithmluminousplus/setup.md
+++ b/docs/games/chunithmluminousplus/setup.md
@@ -310,7 +310,7 @@ Patches for :material-file-cog:`amdaemon.exe`
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmluminousplus/troubleshooting.md) page."
 
 !!! tip
 
@@ -383,8 +383,8 @@ Patches for :material-file-cog:`amdaemon.exe`
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmluminousplus/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmluminousplus/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/chunithmnew/setup.md
+++ b/docs/games/chunithmnew/setup.md
@@ -298,7 +298,7 @@
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmnew/troubleshooting.md) page."
 
 !!! tip
 
@@ -371,8 +371,8 @@
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmnew/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmnew/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/chunithmnewplus/setup.md
+++ b/docs/games/chunithmnewplus/setup.md
@@ -298,7 +298,7 @@
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmnewplus/troubleshooting.md) page."
 
 !!! tip
 
@@ -371,8 +371,8 @@
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmnewplus/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmnewplus/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/chunithmsun/setup.md
+++ b/docs/games/chunithmsun/setup.md
@@ -298,7 +298,7 @@
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmsun/troubleshooting.md) page."
 
 !!! tip
 
@@ -371,8 +371,8 @@
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmsun/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmsun/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/chunithmsunplus/setup.md
+++ b/docs/games/chunithmsunplus/setup.md
@@ -298,7 +298,7 @@
 
 ### First launch
 
-!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chusan/troubleshooting.md) page."
+!!! danger "If you have any issues running the game, refer to the [Troubleshooting](../chunithmsunplus/troubleshooting.md) page."
 
 !!! tip
 
@@ -371,8 +371,8 @@
 
 ### Further configuration
 
-!!! info "Input methods and controllers are covered in the [Controllers](../chusan/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../chunithmsunplus/controllers.md) page."
 
 !!! warning "Have any other issues?"
 
-	Check out the [Troubleshooting](../chusan/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.
+	Check out the [Troubleshooting](../chunithmsunplus/troubleshooting.md) and [Error Codes](../../errorcodes/sega.md) pages.

--- a/docs/games/mu3/controllers.md
+++ b/docs/games/mu3/controllers.md
@@ -101,7 +101,8 @@
 
     If IOConfig still fails to launch, try using the [SelfContained version of ongeki-io](https://github.com/Sanheiii/ongeki-io/releases)
 
-
+---
+    
 ### Arcade hardware and other controllers
 
 !!! tip ""

--- a/docs/games/mu3/troubleshooting.md
+++ b/docs/games/mu3/troubleshooting.md
@@ -36,6 +36,7 @@
     named `amdaemontest.txt` in `App\bin`, which you can send to help people troubleshoot your issue.
 
 ---
+
 ### My game is stuck on a black screen at launch!
 !!! tip ""
 
@@ -46,6 +47,7 @@
         This is likely to be `Assembly-CSharp.dll`, `Assembly-CSharp-firstpass.dll`, and/or `AMDaemon.NET.dll`.
         You can try replacing the DLLs or re-downloading data from elsewhere.
 
+---
 
 ### My game is running too slow/fast or the notes are out of sync!
 

--- a/docs/games/ongekibrightmemory/setup.md
+++ b/docs/games/ongekibrightmemory/setup.md
@@ -33,7 +33,7 @@
 
     Create another empty folder named `AppData` next to them. It should now look like below.
 
-    <img width="500" src="/img/ongeki/sddt/setup/0_ongekidata_withappdata.png"> 
+    <img width="500" src="/img/ongeki/sddt/setup/0_ongekidata_withappdata.png">
 
     The `App` folder should have a file structure as follows.
 
@@ -85,7 +85,7 @@
     If your `amfs` folder already has a file named `ICF1`, skip this step.
 
     In some cases, your data may have a folder containing ICFs in `App\package\amfs`.
-    If so, move all contents inside to the `amfs` folder where `App` and `AppData`, 
+    If so, move all contents inside to the `amfs` folder where `App` and `AppData`,
     delete the `App\package\amfs` folder, and skip this step.
 
     Otherwise, obtain copies of `ICF1` for your game version and place it in
@@ -99,7 +99,7 @@
 
     By default, file extensions on Windows are hidden. Enable them by navigating to
     the `View` tab in File Explorer and select `File name extensions`.
-    
+
 
 #### Installing unprotected executables
 
@@ -138,7 +138,7 @@
 
     Since there is no graphical configuration tool for segatools, you will have to edit the
     configuration file by hand. It is found in `App\bin\segatools.ini`.
-    
+
     It is recommended that you follow along using a text editor with syntax highlighting such as [Notepad++](https://notepad-plus-plus.org/).
 
     Each following sub-section will correspond to a section in `segatools.ini`. If any
@@ -285,13 +285,13 @@
     Press your `Test` button (default `F1`) to enter the service menu. Use the `Service` button
     (default `F2`) to navigate the menu, and `Test` button to select an option.
 
-    Navigate to **ゲーム設定** (`GAME ASSIGNMENTS`, the 5th option).
+    Navigate to **ゲーム設定** (`GAME ASSIGNMENTS`, the 6th option).
 
 <img src="/img/ongeki/sddt/setup/servicemenu/1_gamesettings.png">
 
 !!! tip ""
 
-    Select **グループ内基準機設定** (`SET STANDARD IN GROUP`, the second option)
+    Select **グループ内基準機の設定** (`SET STANDARD IN GROUP`, the second option)
     and toggle this setting to **基準機** (`STANDARD`).
 
 <img src="/img/ongeki/sddt/setup/servicemenu/2_reference.png">
@@ -334,11 +334,11 @@
 
     !!! danger "Please use BepInEx to load all mods including MelonLoader and MonoMods"
 
-    Mods have historically been hardcoded into the unprotected `Assembly-CSharp.dll` which the user can 
-    enable/disable with the `mu3.ini` configuration. The modern approach is to use 
+    Mods have historically been hardcoded into the unprotected `Assembly-CSharp.dll` which the user can
+    enable/disable with the `mu3.ini` configuration. The modern approach is to use
     BepInEx to load custom mods without hardmodding the Assembly-CSharp file.
 
-    To enable BepInEx, download the [BepInEx stable release](https://github.com/BepInEx/BepInEx/releases/latest), 
+    To enable BepInEx, download the [BepInEx stable release](https://github.com/BepInEx/BepInEx/releases/latest),
     extract the BepInEx folder to the `App/package` folder, and modify `segatools.ini` with the following:
 
     ```ini
@@ -351,9 +351,11 @@
     - Melonloader: use [BepInEx.MelonLoader.Loader](https://github.com/BepInEx/BepInEx.MelonLoader.Loader/releases/latest) UnityMono-BepInEx5. Place mods in `MLLoader/Mods`
     - MonoMods: use [BepInEx.MonoMod.Loader](https://github.com/BepInEx/BepInEx.MonoMod.Loader/releases/latest). Place mods in `BepInEx/monomod`
 
+---
+
 ### Controllers and Troubleshooting
 
-!!! info "Input methods and controllers are covered in the [Controllers](../mu3/controllers.md) page."
+!!! info "Input methods and controllers are covered in the [Controllers](../ongekibrightmemory/controllers.md) page."
 
 !!! warning "Have any other issues?"
 


### PR DESCRIPTION
Right now the Troubleshooting and Controllers hyperlinks on the game setup guides for Chuni leads to the `/games/chusan` page while the sidebar menu leads to their game specific pages (i.e `/games/chunithmnewplus/controllers`)

The content is the same, only difference is there will be the game's logo at the top but I think it would be good to use the game-specific links to save any confusion if people choose to navigate to those pages from the setup guide.

Also added some formatting and fixes to ONGEKI stuff that I wasn't able to catch yesterday.