### PR TITLE
Add GoatCounter analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ not_in_nav: |
 
 theme:
   name: material
+  custom_dir: overrides
   logo: img/logo/website-logo.svg
   favicon: img/favicon.ico
   icon:
@@ -211,6 +212,7 @@ theme:
         name: Switch to system preference
   features:
     - content.code.annotate
+    - navigation.instant
 
 markdown_extensions:
   - admonition
@@ -237,3 +239,8 @@ markdown_extensions:
 plugins:
   - search
   - git-revision-date-localized
+
+extra:
+  analytics:
+    provider: custom
+    property: https://two-torial.goatcounter.com/count

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,4 +242,4 @@ plugins:
 extra:
   analytics:
     provider: custom
-    property: https://two-torial.goatcounter.com/count
+    property: https://tuah-torial.goatcounter.com/count

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,7 +212,6 @@ theme:
         name: Switch to system preference
   features:
     - content.code.annotate
-    - navigation.instant
 
 markdown_extensions:
   - admonition

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,7 +1,7 @@
 <script data-goatcounter="{{ config.extra.analytics.property }}"
         {# We also need to disable sending a pageview on load if using instant navigation, see below. #}
         {% if "navigation.instant" in config.theme.features %}
-        data-goatcounter-settings='{"no_onload": true, "allow_local": true}'
+        data-goatcounter-settings='{"no_onload": true}'
         {% endif %}
         async src="//gc.zgo.at/count.js"></script>
 {# 

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,37 @@
+<script data-goatcounter="{{ config.extra.analytics.property }}"
+        {# We also need to disable sending a pageview on load if using instant navigation, see below. #}
+        {% if "navigation.instant" in config.theme.features %}
+        data-goatcounter-settings='{"no_onload": true, "allow_local": true}'
+        {% endif %}
+        async src="//gc.zgo.at/count.js"></script>
+{# 
+    The below code block is for handling "instant navigation" in Material MkDocs.
+    It is currently not applicable to us, but if we wish to switch to it in the future, 
+    this will properly handle URL changes for analytics.
+#}
+{% if "navigation.instant" in config.theme.features %}
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        // GoatCounter might not load, because people might have it blocked
+        // from uBlock Origin or other content blockers.
+        if (!window.goatcounter) {
+            return;
+        }
+
+        let referrer = document.referrer;
+
+        document$.subscribe((d) => {
+            // We don't need to pass the path, because when this observable is called,
+            // `window.location` will already be on the new path.
+            // We still need to manually handle referrals and site titles though.
+            window.goatcounter.count({
+                title: d.querySelector("h1")?.textContent || d.title,
+                referrer,
+            });
+
+            referrer = window.location.href;
+        });
+    });
+</script>
+{% endif %}
+


### PR DESCRIPTION
[GoatCounter](https://www.goatcounter.com/) is a free and [open-source](https://github.com/arp242/goatcounter) privacy-friendly website analytics platform. It does not track any identifying data (see their [privacy policy](https://www.goatcounter.com/help/privacy) and their [GDPR notice](https://www.goatcounter.com/help/gdpr)). Private discussions with other maintainers seem to be mostly positive or neutral, and I think it's useful for seeing what pages are visited often (so we should spend effort polishing).
