### PR TITLE
Update Codex's Chuni guide link to chunithm.org

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -74,7 +74,7 @@
 !!! tip ""
 	- [sdvx.in](https://sdvx.in/chunithm.html) - Chart viewer for CHUNITHM
 	- [CHUNITHM Humen](https://www.youtube.com/@chunithm_humen) - Screen captures of all CHUNITHM charts
-	- Codex's [English Chunithm Guide](https://docs.google.com/document/d/1bsVv3-cOuk_0ZMlLq8joqcwa5YUM_Ff4VnQCgJIkUOk/view) -
+	- Codex's [English Chunithm Guide](chunithm.org) -
 	Handy CHUNITHM resource for players of all skill levels
 
 ---


### PR DESCRIPTION
Honestly, this is just nitpicking, but it appeared to me that we're pushing to use `chunithm.org` instead of the google docs, so I figured we might just update the link in the ressources page