### PR TITLE
Add sections for mai2.ini and mu3.ini (maimai DX and ONGEKI)

### DIFF
--- a/docs/games/sega/maimaidx/common/setup.md
+++ b/docs/games/sega/maimaidx/common/setup.md
@@ -87,27 +87,30 @@
         `Assembly-CSharp.dll` **must** match your game version. All others can be
         reused from other game versions.
 
-        `Assembly-CSharp.dll` **must** also contain `mai2.ini` or `maimaiDX.ini`. These configuration
-        files are specific to the unprotected `Assembly-CSharp.dll`. If your package does not
-        contain a configuration file, please create one with the following to bypass hardware
-        checks on game startup:
+    !!! tip "If the assembly supports it, `App/Package/dpPatchLog.log` lists supported patches after the first run. Otherwise see [Custom Mods](#custom-mods)"
 
-        ```ini
-        [AM]
-        Target=0
-        IgnoreError=1
-        DummyTouchPanel=1
-        DummyLED=1
-        DummyCodeCamera=1
-        DummyPhotoCamera=1
+#### mai2.ini / maimaiDX.ini
 
-        [Sound]
-        Sound8Ch=0
+!!! tip ""
+    Ensure that the `App/Package` folder contains `mai2.ini` (for JPN and EXPORT data) or `maimaiDX.ini` (for CN data).
 
-        [Patches]
-        EnablePatchLog=1
-        ```
-        !!! tip "If the assembly supports it, `App/Package/dpPatchLog.log` lists supported patches after the first run. Otherwise see [Custom Mods](#custom-mods)"
+    If this configuration file is missing, create one using the contents below. Then, rename it according to the region of your data.
+
+    ```ini
+    [AM]
+    Target=0
+    IgnoreError=1
+    DummyTouchPanel=1
+    DummyLED=1
+    DummyCodeCamera=1
+    DummyPhotoCamera=1
+
+    [Sound]
+    Sound8Ch=0
+
+    [Patches]
+    EnablePatchLog=1
+    ```
 
 ---
 

--- a/docs/games/sega/maimaidx/common/troubleshooting.md
+++ b/docs/games/sega/maimaidx/common/troubleshooting.md
@@ -38,6 +38,7 @@
 ---
 
 ### My game is stuck on a black screen at launch!
+
 !!! tip ""
 
     This could also be due to **many** things, the most common of which are:
@@ -54,9 +55,11 @@
 ---
 
 ### My game is stuck on a blue and black screen!
-You need to run the data using unprotected/unpacked files. Please refer to the setup guide to find which ones you need and obtain them.
 
-If you belive you've already done this. You might be missing a try installing the latest [vcredist](https://github.com/abbodi1406/vcredist/releases)
+!!! tip ""
+    You need to run the data using unprotected/unpacked files. Please refer to the setup guide to find which ones you need and obtain them.
+
+    If you believe you've already done this. You might be missing a try installing the latest [vcredist](https://github.com/abbodi1406/vcredist/releases)
 
 ---
 

--- a/docs/games/sega/ongeki/common/setup.md
+++ b/docs/games/sega/ongeki/common/setup.md
@@ -103,7 +103,7 @@
     O.N.G.E.K.I. executables are protected and will not run on a regular computer.
 
     Obtain unprotected (also called "unpacked" or "decrypted" by the community)
-    copies of the following files:
+    copies of the following files and associated configuration file:
 
     - `amdaemon.exe`
     - `mu3.exe`
@@ -111,6 +111,7 @@
     - `mu3_Data\Managed\AMDaemon.NET.dll`
     - `mu3_Data\Managed\Assembly-CSharp-firstpass.dll`
     - `mu3_Data\Managed\Assembly-CSharp.dll`
+    - `mu3.ini`
 
     Copy the files and folders into the `App/Package` folder of your game data. Agree to overwrite
     when asked.
@@ -118,6 +119,30 @@
     !!! Warning "Assembly-CSharp Note"
 
         `Assembly-CSharp.dll` **must** match your game version.
+
+#### mu3.ini
+
+!!! tip ""
+    Ensure that the `App\package` folder contains `mu3.ini`.
+
+    If this configuration file is missing, create one using the contents below.
+
+    ```ini
+    [AM]
+    IgnoreError=1
+    OptionDev=0
+    DummyAime=0
+    DummyCredit=1
+    DummyJVS=0
+
+    [Sound]
+    WasapiExclusive=0
+    ```
+
+    !!! danger "Warning"
+        If you are following the folder structure of this guide, you must ensure that `OptionDev` is set to `0`
+        in your `mu3.ini`, or else your Option data will not load.
+
 
 ---
 


### PR DESCRIPTION
Add a specific section to ensure that at least a basic mu3.ini and mai2.ini configuration file is there before first launch (Normally it comes with unpacked files).

If one is not provided, guide will provide a basic one to allow hardware checks to pass + audio to work.