### PR TITLE
Update spice2x capitalization, and patches information

### DIFF
--- a/docs/extras/datamods.md
+++ b/docs/extras/datamods.md
@@ -110,4 +110,4 @@
 
 	You also need to patch your game's DLL with the `Omnimix` patch.
 	
-	For more information on how to patch your game, head over to the [Spice2x Patching](/extras/patchsp2x.md) page!
+	For more information on how to patch your game, head over to the [spice2x Patching](/extras/patchsp2x.md) page!

--- a/docs/extras/patchsp2x.md
+++ b/docs/extras/patchsp2x.md
@@ -1,4 +1,4 @@
-# Spice2x DLL Patching
+# spice2x DLL Patching
 
 !!! info "TWO-TORIAL Patcher"
 

--- a/docs/extras/patchweb.md
+++ b/docs/extras/patchweb.md
@@ -2,11 +2,11 @@
 
 !!! info "Known web patchers: [Resources](/resources.md#web-patchers)"
 
-!!! warning "For BEMANI games consider [Spice2x Patching](patchsp2x.md)"
+!!! warning "For BEMANI games consider [spice2x Patching](patchsp2x.md)"
 
 	**This patching method is outdated for BEMANI games.**
 
-	However spice2x patching is still very new and might not support your game yet, in this case follow this guide.
+	However if your game isn't supported, follow this guide.
 
 !!! danger "Before proceeding"
 

--- a/docs/games/bemani/ddr/common/setup.md
+++ b/docs/games/bemani/ddr/common/setup.md
@@ -78,11 +78,11 @@
 	- If it instead corresponds to your pre-patch datecode, replace it with the new one and save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 ??? tip "For MDX-001 (32 bits)"
 
@@ -98,7 +98,7 @@
   
 	<img src="/img/bemani/ddr/common/setup/spice2x64data.png">
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -143,7 +143,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! danger "To prevent issues, avoid patching things you don't need or understand."
 

--- a/docs/games/bemani/gitadora/fuzzup/setup.md
+++ b/docs/games/bemani/gitadora/fuzzup/setup.md
@@ -4,11 +4,11 @@
 !!! danger "Please make sure you downloaded your data from an appropriate source.<br>This guide is unable to troubleshoot any problems related to bad or poorly managed data."
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -43,7 +43,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! danger "To prevent issues, avoid patching things you don't need or understand."
 

--- a/docs/games/bemani/iidx/24_sinobuz/setup.md
+++ b/docs/games/bemani/iidx/24_sinobuz/setup.md
@@ -25,11 +25,11 @@
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -39,7 +39,7 @@
 	<img src="/img/bemani/iidx/24_sinobuz/spice2xdata.png">
 
 ---
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -99,7 +99,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! danger "To prevent issues, avoid patching things you don't need or understand."
 

--- a/docs/games/bemani/iidx/30_resident/setup.md
+++ b/docs/games/bemani/iidx/30_resident/setup.md
@@ -45,7 +45,7 @@
 	If extra files are present next to your folders, such as executables, scripts, etc.. **remove them**.  
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
-!!! info "If you don't need to update your data, you can skip over to the [Installing Spice2x](#installing-spice2x) section."
+!!! info "If you don't need to update your data, you can skip over to the [Installing spice2x](#installing-spice2x) section."
 
 ---
 ### Updating data
@@ -82,11 +82,11 @@
 	Now save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -95,7 +95,7 @@
   
 	<img src="/img/bemani/iidx/common/setup/spice2x64data.png">
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -159,11 +159,7 @@
 
 #### Patches
 
-!!! info "As of writing, web patching is recommended for IIDX 30 Resident as opposed to spice2x patching."
-
-	Spice2x patching is fairly new and the game's latest releases are prioritized for conversion.
-
-	For now use [Mon's BemaniPatcher](https://mon.im/bemanipatcher/iidx30resident.html), more info can be found in the [web patching](/extras/patchweb.md) page.
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! danger "As a general rule of thumb, if you're not sure what a patch does or you're not absolutely certain you need it, leave it alone, regardless of recommendations below."
 

--- a/docs/games/bemani/iidx/31_epolis/setup.md
+++ b/docs/games/bemani/iidx/31_epolis/setup.md
@@ -64,7 +64,7 @@
 	If extra files are present next to your folders, such as executables, scripts, etc.. **remove them**.  
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
-!!! info "If you don't need to update your data, you can skip over to the [Installing Spice2x](#installing-spice2x) section."
+!!! info "If you don't need to update your data, you can skip over to the [Installing spice2x](#installing-spice2x) section."
 
 ---
 ### Updating data
@@ -113,11 +113,11 @@
 	Now save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -126,7 +126,7 @@
   
 	<img src="/img/bemani/iidx/common/setup/spice2x64data.png">
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -190,7 +190,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! tip ""
 

--- a/docs/games/bemani/iidx/32_pinkycrush/setup.md
+++ b/docs/games/bemani/iidx/32_pinkycrush/setup.md
@@ -64,7 +64,7 @@
 	If extra files are present next to your folders, such as executables, scripts, etc.. **remove them**.  
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
-!!! info "If you don't need to update your data, you can skip over to the [Installing Spice2x](#installing-spice2x) section."
+!!! info "If you don't need to update your data, you can skip over to the [Installing spice2x](#installing-spice2x) section."
 
 ---
 ### Updating data
@@ -113,11 +113,11 @@
 	Now save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -126,7 +126,7 @@
   
 	<img src="/img/bemani/iidx/common/setup/spice2x64data.png">
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -190,7 +190,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! tip ""
 

--- a/docs/games/bemani/popn/common/setup.md
+++ b/docs/games/bemani/popn/common/setup.md
@@ -31,7 +31,7 @@
 	If extra files are present next to your folders, such as executables, scripts, etc.. **remove them**.  
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
-!!! info "If you don't need to update your data, you can skip over to the [Installing Spice2x](#installing-spice2x) section."
+!!! info "If you don't need to update your data, you can skip over to the [Installing spice2x](#installing-spice2x) section."
 
 ---
 ### Updating data
@@ -66,11 +66,11 @@
 	- If it instead corresponds to your pre-patch datecode, replace it with the new one and save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -80,7 +80,7 @@
 	<img src="/img/bemani/popn/common/setup/spice2x32data.png">
 
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -124,7 +124,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! danger "To prevent issues, avoid patching things you don't need or understand."
 

--- a/docs/games/bemani/sdvx/6_exceedgear/setup.md
+++ b/docs/games/bemani/sdvx/6_exceedgear/setup.md
@@ -29,7 +29,7 @@
 	If extra files are present next to your folders, such as executables, scripts, etc.. **remove them**.  
 	**This also means your data was tampered with and we strongly recommend getting new data from somewhere else.**
 
-!!! info "If you don't need to update your data, you can skip over to the [Installing Spice2x](#installing-spice2x) section."
+!!! info "If you don't need to update your data, you can skip over to the [Installing spice2x](#installing-spice2x) section."
 
 ---
 ### Updating data
@@ -64,11 +64,11 @@
 	- If it instead corresponds to our pre-patch datecode, replace it with the new one and save the file.
 
 ---
-### Installing Spice2x
+### Installing spice2x
 
 !!! info ""
 
-	If you already have Spice2x installed, make sure it is up to date!
+	If you already have spice2x installed, make sure it is up to date!
 
 !!! tip ""
 
@@ -85,7 +85,7 @@
 
 	<img src="/img/bemani/sdvx/6_exceedgear/setup/dllamd.png">
 
-### Configuring Spice2x
+### Configuring spice2x
 
 !!! info "Open `spicecfg.exe`, each following sub-section corresponds to a tab at the top."
 
@@ -146,7 +146,7 @@
 
 #### Patches
 
-!!! info "Go through the [Spice2x Patching](/extras/patchsp2x.md) page to import patches."
+!!! info "Go through the [spice2x Patching](/extras/patchsp2x.md) page to import patches."
 
 !!! tip ""
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,10 +1,10 @@
 # Other Resources
 
 ---
-### Spice2x Patchers
-!!! tip "See [Spice2x Patching](./extras/patchsp2x.md)."
+### spice2x Patchers
+!!! tip "See [spice2x Patching](./extras/patchsp2x.md)."
 
-	- **TWO-TORIAL** - `https://sp2x.two-torial.xyz/` - **Our [open-source](https://github.com/two-torial/sp2xpatcher) patcher for Spice2x compatible games.**
+	- **TWO-TORIAL** - `https://sp2x.two-torial.xyz/` - **Our [open-source](https://github.com/two-torial/sp2xpatcher) patcher for spice2x compatible games.**
 	- **DJTrackers** - `https://djtrackers.com/bemanipatcher/2x` - **Recommended for anything we don't yet support. Our IIDX patches are based off of theirs for the most part.**
 
 ---
@@ -12,7 +12,7 @@
 
 !!! tip "See [Web Patching](./extras/patchweb.md)."
 
-	- [TWO-TORIAL](https://patcher.two-torial.xyz/) - **Our [open-source](https://github.com/two-torial/webpatcher) web patcher** *(based on mon's)* **for games incompatible with Spice2x.** Also integrates Scribbler's patches for chunithm.
+	- [TWO-TORIAL](https://patcher.two-torial.xyz/) - **Our [open-source](https://github.com/two-torial/webpatcher) web patcher** *(based on mon's)* **for games incompatible with spice2x.** Also integrates Scribbler's patches for chunithm.
 	- [mon's](https://mon.im/bemanipatcher/) - The longest lasting web patcher, supports a variety of **n-1 and older** games.
 	- [Scribbler's Chuni Only Patcher](https://scrib-bler.github.io/patcher/) - Has every version of **Chunithm** available.
 
@@ -21,7 +21,7 @@
 
 !!! tip ""
 
-	- [Spice2x Wiki](https://github.com/spice2x/spice2x.github.io/wiki) - The best resource for Spice2x
+	- [spice2x Wiki](https://github.com/spice2x/spice2x.github.io/wiki) - The best resource for spice2x
 	- [Bemaniwiki](https://bemaniwiki.com/) - A bemani wiki written in japanese
 	- [wikiwiki](https://wikiwiki.jp/) - A japanese game wiki, good for comparing against SilentBlue
 	- [Namuwiki](https://namu.wiki/) - A korean wiki for bemani and more 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ nav:
     - BEMANI: "errorcodes/bemani.md"
     - SEGA: "errorcodes/sega.md"
   - Game Patching:
-    - "Using Spice2x": "extras/patchsp2x.md"
+    - "Using spice2x": "extras/patchsp2x.md"
     - "Using Web": "extras/patchweb.md"
     - "Manually": "extras/hexguide.md"
   - Extras:


### PR DESCRIPTION
- Change all mentions of "Spice2x" to "spice2x" to be consistent.
- Remove the warning that spice2x patching is new and might not support the game on IIDX30's guide and the Web Patching page.